### PR TITLE
check if value is object before checking if method_exists

### DIFF
--- a/packages/Phased/State/Factories/VuexFactory.php
+++ b/packages/Phased/State/Factories/VuexFactory.php
@@ -409,7 +409,7 @@ class VuexFactory implements Arrayable, Jsonable, JsonSerializable
      */
     public function verifyState($state)
     {
-        if (method_exists($state, 'toArray')) {
+        if (is_object($state) && method_exists($state, 'toArray')) {
             $state = $state->toArray();
         } elseif (is_array($state)) {
             $state = collect($state)->toArray();
@@ -418,7 +418,7 @@ class VuexFactory implements Arrayable, Jsonable, JsonSerializable
         }
 
         foreach ($state as $key => $value) {
-            if (method_exists($value, 'toArray')) {
+            if (is_object($value) && method_exists($value, 'toArray')) {
                 $state[$key] = $value->toArray();
             }
         }


### PR DESCRIPTION
https://stackoverflow.com/questions/70584290/php-8-0-method-exists-on-non-object-causes-fatal-typeerror
https://bugs.php.net/bug.php?id=79623
https://www.php.net/manual/en/function.method-exists.php

```php
/**
 * Checks if the class method exists
 * @link https://php.net/manual/en/function.method-exists.php
 * @param object|string $object_or_class <p>
 * An object instance or a class name
 * </p>
 * @param string $method <p>
 * The method name
 * </p>
 * @return bool true if the method given by <i>method_name</i>
 * has been defined for the given <i>object</i>, false
 * otherwise.
 */
#[Pure]
function method_exists($object_or_class, string $method): bool {}
```